### PR TITLE
커밋 시점 기록 추가

### DIFF
--- a/Dit/Dit.xcdatamodeld/Dit.xcdatamodel/contents
+++ b/Dit/Dit.xcdatamodeld/Dit.xcdatamodel/contents
@@ -4,9 +4,10 @@
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="isDone" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <elements>
-        <element name="Todos" positionX="-63" positionY="-18" width="128" height="89"/>
+        <element name="Todos" positionX="-63" positionY="-18" width="128" height="104"/>
     </elements>
 </model>

--- a/Dit/HomeViewController.swift
+++ b/Dit/HomeViewController.swift
@@ -80,7 +80,7 @@ extension HomeViewController: UISearchBarDelegate {
             return
         }
         
-        todos.append(Todo(text: text, isDone: false, createdAt: date, uuid: uuid))
+        todos.append(Todo(text: text, isDone: false, createdAt: date, uuid: uuid, updatedAt: date))
         searchController.isActive = false
         reloadTableView()
     }
@@ -109,6 +109,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
                         let targetTodo = data[0]
                         
                         targetTodo.setValue(true, forKey: "isDone")
+                        targetTodo.setValue(Date(), forKey: "updatedAt")
                         
                         try self.container.viewContext.save()
                     } catch {
@@ -138,6 +139,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
                         let targetTodo = data[0]
                         
                         targetTodo.setValue(false, forKey: "isDone")
+                        targetTodo.setValue(Date(), forKey: "updatedAt")
                         
                         try self.container.viewContext.save()
                     } catch {
@@ -258,16 +260,17 @@ private extension HomeViewController {
             guard let text = todo.value(forKey: "text") as? String,
                   let isDone = todo.value(forKey: "isDone") as? Bool,
                   let createdAt = todo.value(forKey: "createdAt") as? Date,
+                  let updatedAt = todo.value(forKey: "updatedAt") as? Date,
                   let uuid = todo.value(forKey: "uuid") as? UUID
             else {
                 return nil
             }
-            return Todo(text: text, isDone: isDone, createdAt: createdAt, uuid: uuid)
+            return Todo(text: text, isDone: isDone, createdAt: createdAt, uuid: uuid, updatedAt: updatedAt)
         }
         
         let readDoneRequest = NSFetchRequest<NSManagedObject>(entityName: "Todos")
-        let todayPredicate = NSPredicate(format: "createdAt >= %@", today as CVarArg)
-        let tomorrowPredicate = NSPredicate(format: "createdAt < %@", tomorrow as CVarArg)
+        let todayPredicate = NSPredicate(format: "updatedAt >= %@", today as CVarArg)
+        let tomorrowPredicate = NSPredicate(format: "updatedAt < %@", tomorrow as CVarArg)
         let isDonePredicate = NSPredicate(format: "isDone == YES")
         let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [todayPredicate, tomorrowPredicate, isDonePredicate])
         readDoneRequest.predicate = compound
@@ -277,11 +280,12 @@ private extension HomeViewController {
             guard let text = todo.value(forKey: "text") as? String,
                   let isDone = todo.value(forKey: "isDone") as? Bool,
                   let createdAt = todo.value(forKey: "createdAt") as? Date,
+                  let updatedAt = todo.value(forKey: "updatedAt") as? Date,
                   let uuid = todo.value(forKey: "uuid") as? UUID
             else {
                 return nil
             }
-            return Todo(text: text, isDone: isDone, createdAt: createdAt, uuid: uuid)
+            return Todo(text: text, isDone: isDone, createdAt: createdAt, uuid: uuid, updatedAt: updatedAt)
         }
 
         reloadTableView()

--- a/Dit/Todo.swift
+++ b/Dit/Todo.swift
@@ -13,4 +13,5 @@ struct Todo {
     var isDone: Bool
     let createdAt: Date
     let uuid: UUID
+    let updatedAt: Date
 }

--- a/Todos+CoreDataProperties.swift
+++ b/Todos+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Todos+CoreDataProperties.swift
 //  Dit
 //
-//  Created by 강태준 on 2022/09/06.
+//  Created by 강태준 on 2022/09/07.
 //
 //
 
@@ -20,6 +20,7 @@ extension Todos {
     @NSManaged public var isDone: Bool
     @NSManaged public var text: String?
     @NSManaged public var uuid: UUID?
+    @NSManaged public var updatedAt: Date?
 
 }
 


### PR DESCRIPTION
## 개요
기존에 createdAt 기반으로 today's commit을 관리하던 것을 updatedAt 컬럼을 추가하여 커밋(변경) 시점 기록

## 작업사항
- updatedAt 컬럼을 Todo에 추가
- 기존 createdAt으로 관리하던 부분을 updatedAt으로 변경

## 변경로직
- 기존 Todo 추가/수정 부분에서 createdAt으로만 관리하던 로직을 updatedAt을 추가하여 관리