### PR TITLE
Todo 추가 후 앱 종료 시 저장되지 않는 에러 해결

### DIFF
--- a/Dit/Todo.swift
+++ b/Dit/Todo.swift
@@ -13,5 +13,5 @@ struct Todo {
     var isDone: Bool
     let createdAt: Date
     let uuid: UUID
-    let updatedAt: Date
+    var updatedAt: Date
 }


### PR DESCRIPTION
## 개요
Todo 추가 후 앱 종료 시 저장되지 않는 에러 해결

## 작업사항
- updatedAt을 추가하지 않았던 Todo 관련 로직 수정
- container.viewContext로 접근하던 부분을 context 전역변수를 만들어 수정

## 변경로직
- `container.viewContext`를 사용하던 부분을 `context` 클래스 변수를 만들어 수정
- todo 추가 부분에서 updatedAt이 누락된 부분 수정